### PR TITLE
Fixes betting during the EVO event

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,11 +3,11 @@
 
 	"name": "SaltBot",
 	"description": "This extension automates betting on SaltyBet.com.",
-	"version": "1.9.9",
+	"version": "1.9.10",
 	"permissions": ["storage", "unlimitedStorage", "tabs", "alarms"],
 	"content_scripts": [
 		{
-			"matches": ["http://www.saltybet.com/*", "http://www.twitch.tv/saltybet"],
+			"matches": ["http://*.saltybet.com/*", "http://www.twitch.tv/saltybet"],
 			"js": ["lib/FileSaver.min.js", "records.js", "tracker.js", "strategy.js", "salty.js", "twitch_content.js"]
 		}
 	],

--- a/src/records.js
+++ b/src/records.js
@@ -265,7 +265,7 @@ var ir = function(f) {
 	});
 };
 
-if (window.location.href == "http://www.saltybet.com/")
+if (window.location.href == "http://www.saltybet.com/" || window.location.href == "http://mugen.saltybet.com/")
 	chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 		switch(request.type) {
 		case "dr":

--- a/src/salty.js
+++ b/src/salty.js
@@ -335,7 +335,7 @@ Controller.prototype.saveSettings = function(msg) {
 };
 
 ctrl = null;
-if (window.location.href == "http://www.saltybet.com/") {
+if (window.location.href == "http://www.saltybet.com/" || window.location.href == "http://mugen.saltybet.com/") {
 	ctrl = new Controller();
 	ctrl.ensureTwitch();
 	chrome.storage.local.get(["settings_v1"], function(results) {

--- a/src/twitch_background.js
+++ b/src/twitch_background.js
@@ -3,7 +3,7 @@ chrome.extension.onMessage.addListener(function(details) {
 		//Receive message from Waifu, pass it on to salty tab
 		chrome.tabs.query({
 			title : "Salty Bet",
-			url : "http://www.saltybet.com/"
+			url : "http://*.saltybet.com/"
 		}, function(result) {
 			// result is an array of tab.Tabs
 			for (var i = 0; i < result.length; i++) {
@@ -35,7 +35,7 @@ var sendUpdatedChromosome = function() {
 			var data = JSON.stringify(results.chromosomes_v1[0]);
 			chrome.tabs.query({
 				title : "Salty Bet",
-				url : "http://www.saltybet.com/"
+				url : "http://*.saltybet.com/"
 			}, function(result) {
 				chrome.tabs.sendMessage(result[0].id, {
 					type : "suc",


### PR DESCRIPTION
During the EVO event SaltyBet can only be reached under the URL
mugen.saltybet.com. The changes made enable the saltbot to bet on
mugen.saltybet.com too.

Fixes #47 