### PR TITLE
Merge ready to synkarius/saltbot/new mutation method

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -380,7 +380,7 @@ Simulator.prototype.evalMutations = function (mode) {
 			var parents = [];
 			var nextGeneration = [];
 			var money = true;
-			var accuracy = false;
+			var accuracy = true;
 			var unshackle = true;
 
 			if (mode == "evolution") {
@@ -389,6 +389,7 @@ Simulator.prototype.evalMutations = function (mode) {
 					if (unshackle) penalty = 1;
 					sortingArray.push([orders[l].chromosome, totalPercentCorrect[l], self.money[l], penalty]);
 				}
+				//	sort the the best in order.
 				sortingArray.sort(function (a, b) {
 					if (!money && accuracy)
 						return (b[1] * b[3]) - (a[1] * a[3]);
@@ -397,8 +398,11 @@ Simulator.prototype.evalMutations = function (mode) {
 					return (b[1] * b[2] * b[3]) - (a[1] * a[2] * a[3]);
 				});
 
-				var top = Math.round(sortingArray.length / 2);
-				for (var o = 0; o < top; o++) {
+				var sizeNextGen = sortingArray.length;
+				var ratioTopKeep = 0.10;
+				var ratioTopBestBreeding = 0.5;
+				var sizeTopParents = Math.floor(sizeNextGen * ratioTopKeep);		// keep half of sorted population
+				for (var o = 0; o < sizeTopParents; o++) {
 					parents.push(sortingArray[o][0]);
 					//ranking guarantees that we send the best one
 					sortingArray[o][0].rank = o + 1;
@@ -406,20 +410,29 @@ Simulator.prototype.evalMutations = function (mode) {
 				}
 				// i really only need to see the best one
 				console.log(sortingArray[0][0].toDisplayString() + " -> " + sortingArray[0][1].toFixed(4) + "%,  $" + parseInt(sortingArray[0][2]).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","));
-				//
-				for (var mf = 0; mf < parents.length; mf++) {
+				// created and push children of that half of best sorted population
+				for (var mf = 0; mf < sizeNextGen-sizeTopParents ; mf++) {
 					var parent1 = null;
 					var parent2 = null;
 					var child = null;
-					if (mf == 0) {
+					if (mf == 0) {		// breed the best to the worst parents kept.
 						parent1 = parents[0];
-						parent2 = parents[parents.length - 1];
-					} else if (mf <= 4) {
+						parent2 = parents[sizeTopParents - 1];
+					} else if (mf < sizeTopParents * ratioTopBestBreeding) {		// breed the best with next few best kept
 						parent1 = parents[0];
 						parent2 = parents[mf];
-					} else {
-						parent1 = parents[mf - 1];
-						parent2 = parents[mf];
+					} else if (mf < sizeTopParents){			// breed best kept remaining
+						parent1 = parents[mf];			
+						parent2 = sortingArray[sizeTopParents + Math.floor(Math.random() * (sizeTopParents))][0];	// pick random after top
+					} else {		// fill remaining population by random breeding below the best kept.
+						var attemps = 2;
+						var atmp = 0;
+						do {							
+							parent1 = sortingArray[sizeTopParents + Math.floor(Math.random() * (sizeNextGen - sizeTopParents))][0];
+							parent2 = sortingArray[sizeTopParents + Math.floor(Math.random() * (sizeNextGen - sizeTopParents))][0];
+							atmp++;
+						} 
+						while ((parent1 != parent2) && (atmp < attemps));
 					}
 					child = parent1.mate(parent2);
 					nextGeneration.push(child);
@@ -488,9 +501,10 @@ Simulator.prototype.initializePool = function () {
 	}
 	var newPool = [];
 	for (var i = 0; i < pool.length; i++) {
-		// if (i % 5 == 0) {
-		// 	console.log(pool[i].toDisplayString());
-		// }
+
+		if (i % 5 == 0) {
+			console.log(pool[i].toDisplayString());
+		}
 		newPool.push(pool[i]);
 	}
 	chrome.storage.local.set({

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -205,43 +205,43 @@ RatioConfidence.prototype.execute = function (info) {
 var Chromosome = function () {
 	// confidence weights
 	this.oddsWeight = 1;
-	this.timeWeight = 1;
+	this.timeWeight = 0.5;
 	this.winPercentageWeight = 1;
 	this.crowdFavorWeight = 1;
 	this.illumFavorWeight = 1;
-	// tier scoring
-	this.wX = 1;
-	this.wS = 1;
-	this.wA = 1;
-	this.wB = 1;
+	// tier scoring            
+	this.wX = 5;
+	this.wS = 4;
+	this.wA = 3;
+	this.wB = 2;
 	this.wP = 1;
-	this.wU = 1;
+	this.wU = 0.5;
 	this.lX = 1;
-	this.lS = 1;
-	this.lA = 1;
-	this.lB = 1;
-	this.lP = 1;
-	this.lU = 1;
+	this.lS = 2;
+	this.lA = 3;
+	this.lB = 4;
+	this.lP = 5;
+	this.lU = 0.5;
 	// odds weights
-	this.oX = 1;
-	this.oS = 1;
-	this.oA = 1;
-	this.oB = 1;
+	this.oX = 5;
+	this.oS = 4;
+	this.oA = 3;
+	this.oB = 2;
 	this.oP = 1;
-	this.oU = 1;
+	this.oU = 0.5;
 	// times weights
-	this.wtX =	1;
-	this.wtS =	1;
-	this.wtA =	1;
-	this.wtB =	1;
-	this.wtP =	1;
-	this.wtU =	1;
-	this.ltX =	1;
-	this.ltS =	1;
-	this.ltA =	1;
-	this.ltB =	1;
-	this.ltP =	1;
-	this.ltU =	1;
+	this.wtX = 5;
+	this.wtS = 4;
+	this.wtA = 3;
+	this.wtB = 2;
+	this.wtP = 1;
+	this.wtU = 0.5;
+	this.ltX = 1;
+	this.ltS = 2;
+	this.ltA = 3;
+	this.ltB = 4;
+	this.ltP = 5;
+	this.ltU = 0.5;
 	return this;
 };
 
@@ -255,7 +255,8 @@ Chromosome.prototype.normalize = function(){
 	
 	for (var el2 in this) {
 		if (this.hasOwnProperty(el2)) {
-			this[el2] /= (sum);
+			//* 0.01 because of normalizing to a sum of 100
+			this[el2] /= (sum * 0.01);
 		}
 	}
 }

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -205,43 +205,43 @@ RatioConfidence.prototype.execute = function (info) {
 var Chromosome = function () {
 	// confidence weights
 	this.oddsWeight = 1;
-	this.timeWeight = 0.5;
+	this.timeWeight = 1;
 	this.winPercentageWeight = 1;
 	this.crowdFavorWeight = 1;
 	this.illumFavorWeight = 1;
-	// tier scoring            
-	this.wX = 5;
-	this.wS = 4;
-	this.wA = 3;
-	this.wB = 2;
+	// tier scoring
+	this.wX = 1;
+	this.wS = 1;
+	this.wA = 1;
+	this.wB = 1;
 	this.wP = 1;
-	this.wU = 0.5;
+	this.wU = 1;
 	this.lX = 1;
-	this.lS = 2;
-	this.lA = 3;
-	this.lB = 4;
-	this.lP = 5;
-	this.lU = 0.5;
+	this.lS = 1;
+	this.lA = 1;
+	this.lB = 1;
+	this.lP = 1;
+	this.lU = 1;
 	// odds weights
-	this.oX = 5;
-	this.oS = 4;
-	this.oA = 3;
-	this.oB = 2;
+	this.oX = 1;
+	this.oS = 1;
+	this.oA = 1;
+	this.oB = 1;
 	this.oP = 1;
-	this.oU = 0.5;
+	this.oU = 1;
 	// times weights
-	this.wtX = 5;
-	this.wtS = 4;
-	this.wtA = 3;
-	this.wtB = 2;
-	this.wtP = 1;
-	this.wtU = 0.5;
-	this.ltX = 1;
-	this.ltS = 2;
-	this.ltA = 3;
-	this.ltB = 4;
-	this.ltP = 5;
-	this.ltU = 0.5;
+	this.wtX =	1;
+	this.wtS =	1;
+	this.wtA =	1;
+	this.wtB =	1;
+	this.wtP =	1;
+	this.wtU =	1;
+	this.ltX =	1;
+	this.ltS =	1;
+	this.ltA =	1;
+	this.ltB =	1;
+	this.ltP =	1;
+	this.ltU =	1;
 	return this;
 };
 
@@ -255,8 +255,7 @@ Chromosome.prototype.normalize = function(){
 	
 	for (var el2 in this) {
 		if (this.hasOwnProperty(el2)) {
-			//* 0.01 because of normalizing to a sum of 100
-			this[el2] /= (sum * 0.01);
+			this[el2] /= (sum);
 		}
 	}
 }

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -208,41 +208,41 @@ var Chromosome = function () {
 	this.timeWeight = 0.5		/82	;
 	this.winPercentageWeight = 1/82	;
 	this.crowdFavorWeight = 1	/82	;
-	this.illumFavorWeight = 1	/82	;
+	this.illumFavorWeight = 1	/82	;// 4.5 // these are sums for normalization, temporary here for sanity.
 	// tier scoring            
 	this.wX = 5					/82	;
 	this.wS = 4					/82	;
 	this.wA = 3					/82	;
 	this.wB = 2					/82	;
 	this.wP = 1					/82	;
-	this.wU = 0.5				/82	;
+	this.wU = 0.5				/82	;// 15.5
 	this.lX = 1					/82	;
 	this.lS = 2					/82	;
 	this.lA = 3					/82	;
 	this.lB = 4					/82	;
 	this.lP = 5					/82	;
-	this.lU = 0.5				/82	;
+	this.lU = 0.5				/82	;// 15.5
 	// odds weights
-		this.oX = 5					/82	;
+	this.oX = 5					/82	;
 	this.oS = 4					/82	;
 	this.oA = 3					/82	;
 	this.oB = 2					/82	;
 	this.oP = 1					/82	;
-	this.oU = 0.5				/82	;
+	this.oU = 0.5				/82	;// 15.5
 	// times weights
 	this.wtX = 5				/82	;
 	this.wtS = 4				/82	;
 	this.wtA = 3				/82	;
 	this.wtB = 2				/82	;
 	this.wtP = 1				/82	;
-	this.wtU = 0.5				/82	;
+	this.wtU = 0.5				/82	;// 15.5
 	this.ltX = 1				/82	;
 	this.ltS = 2				/82	;
 	this.ltA = 3				/82	;
 	this.ltB = 4				/82	;
 	this.ltP = 5				/82	;
-	this.ltU = 0.5				/82	;
-	return this;
+	this.ltU = 0.5				/82	;// 15.5
+	return this;					 // total=82
 };
 
 Chromosome.prototype.normalize = function(){

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -204,44 +204,44 @@ RatioConfidence.prototype.execute = function (info) {
 
 var Chromosome = function () {
 	// confidence weights
-	this.oddsWeight = 1;
-	this.timeWeight = 0.5;
-	this.winPercentageWeight = 1;
-	this.crowdFavorWeight = 1;
-	this.illumFavorWeight = 1;
+	this.oddsWeight = 1			/82	;
+	this.timeWeight = 0.5		/82	;
+	this.winPercentageWeight = 1/82	;
+	this.crowdFavorWeight = 1	/82	;
+	this.illumFavorWeight = 1	/82	;
 	// tier scoring            
-	this.wX = 5;
-	this.wS = 4;
-	this.wA = 3;
-	this.wB = 2;
-	this.wP = 1;
-	this.wU = 0.5;
-	this.lX = 1;
-	this.lS = 2;
-	this.lA = 3;
-	this.lB = 4;
-	this.lP = 5;
-	this.lU = 0.5;
+	this.wX = 5					/82	;
+	this.wS = 4					/82	;
+	this.wA = 3					/82	;
+	this.wB = 2					/82	;
+	this.wP = 1					/82	;
+	this.wU = 0.5				/82	;
+	this.lX = 1					/82	;
+	this.lS = 2					/82	;
+	this.lA = 3					/82	;
+	this.lB = 4					/82	;
+	this.lP = 5					/82	;
+	this.lU = 0.5				/82	;
 	// odds weights
-	this.oX = 5;
-	this.oS = 4;
-	this.oA = 3;
-	this.oB = 2;
-	this.oP = 1;
-	this.oU = 0.5;
+		this.oX = 5					/82	;
+	this.oS = 4					/82	;
+	this.oA = 3					/82	;
+	this.oB = 2					/82	;
+	this.oP = 1					/82	;
+	this.oU = 0.5				/82	;
 	// times weights
-	this.wtX = 5;
-	this.wtS = 4;
-	this.wtA = 3;
-	this.wtB = 2;
-	this.wtP = 1;
-	this.wtU = 0.5;
-	this.ltX = 1;
-	this.ltS = 2;
-	this.ltA = 3;
-	this.ltB = 4;
-	this.ltP = 5;
-	this.ltU = 0.5;
+	this.wtX = 5				/82	;
+	this.wtS = 4				/82	;
+	this.wtA = 3				/82	;
+	this.wtB = 2				/82	;
+	this.wtP = 1				/82	;
+	this.wtU = 0.5				/82	;
+	this.ltX = 1				/82	;
+	this.ltS = 2				/82	;
+	this.ltA = 3				/82	;
+	this.ltB = 4				/82	;
+	this.ltP = 5				/82	;
+	this.ltU = 0.5				/82	;
 	return this;
 };
 
@@ -285,13 +285,13 @@ Chromosome.prototype.toDisplayString = function () {
 Chromosome.prototype.mate = function (other) {
 	var offspring = new Chromosome();
 	for (var i in offspring) {
-		var mutationScale = 0.5;	// range 0..<1 (a danger if offspring weight becomes < 0).
-		var mutationChance = 0.21;	// range 0..1
+		var mutationScale = 0.20;	// range 0..<1 (a danger if offspring weight becomes < 0).
+		var mutationChance = 0.15;	// range 0..1
 		if (typeof offspring[i] != "function") {
 			offspring[i] = (Math.random() > 0.5) ? this[i] : other[i];
 			var radiation =  (Math.random() - 0.5) * 2.0;
 			var change = offspring[i] * radiation * mutationScale;
-			if (Math.random() < mutationChance && offspring[i] != null)
+			if ((Math.random() < mutationChance) && (offspring[i] != null))
 				offspring[i] += change;
 		}
 	}
@@ -538,11 +538,11 @@ ConfidenceScore.prototype.execute = function (info) {
 	/*---------------------------------------------------------------------------------------------------*/
 	// CONFIDENCE ADJUSTMENT SECTION
 	/*---------------------------------------------------------------------------------------------------*/
-
+	var nerfPoorScore = 0.66;
 	var nerfAmount = 0;
 	var nerfMsg = "-- PROBLEMS:";
 	if ((c1Score == c2Score) || c1.wins.length + c1.losses.length <= 3 || c2.wins.length + c2.losses.length <= 3) {
-		nerfAmount += .3;
+		nerfAmount += nerfPoorScore;
 		nerfMsg += "\n- insufficient information (scores: " + c1Score.toFixed(2) + ":" + c2Score.toFixed(2) + "), W:L(P1)(P2)-> (" + c1.wins.length + ":" + c1.losses.length + ")(" + c2.wins.length + ":" + c2.losses.length + "), ";
 	}
 


### PR DESCRIPTION
Release ready changes to the mutation sim. This was a study to see how i can improve saltbot's chromosome evolution sim using methods i learned in my evo. sim. and computer science studies.  
I discovered glaring bugs in the original mate, mutation, sim pool, and breeding functions; the sim is less likely to find and get stuck in poor maxima's of best strategy, or never mutate out of them.  The sim should be more optimized for discovering and handling changing match data when find optimal winning chromosomes (under current heuristics for determining best chromosomes). 

Performance changes:  
Given new current pool size (my default value set a 100 ), generations on my system take 15-35 seconds. This is trade-off is is for better results over time (And it could even be higher!).
Given current match data + plus a few weeks of my own;  its found  a good +61-65%  in about 30 generations, in further generations, 50-150, expect to see the total winnings to go up in large jumps as natural selection "finds its way" (about 50mill for me as i left off).   

Know that when importing a chromosome or starting fresh, you will lose the currently-saved pool, the sim will need to clone and mutate an entire pool size with that import, this is bad as alternative chromosome strategies saved in the pool are lost, so new generations must run and mutate out again. This is something that needs improvement, by saving the whole pool when exporting. Keep this in mind when you test this, i suggest running the generations extra longer, maybe 50+.

To see finer details of changes, check my the walking commit log documenting my study.